### PR TITLE
[Style] remove code blocks' shadow

### DIFF
--- a/docs/themes/hugo-theme-docdock-master/static/theme-flex/style.css
+++ b/docs/themes/hugo-theme-docdock-master/static/theme-flex/style.css
@@ -366,7 +366,7 @@ article section.page {
       vertical-align: bottom; }
   article section.page code {
     font-family: "RobotoMono", monospace;
-	  border-radius: 3px; }
+	border-radius: 3px; }
   article section.page p > code,
   article section.page li code,
   article section.page table code {

--- a/docs/themes/hugo-theme-docdock-master/static/theme-flex/style.css
+++ b/docs/themes/hugo-theme-docdock-master/static/theme-flex/style.css
@@ -366,8 +366,7 @@ article section.page {
       vertical-align: bottom; }
   article section.page code {
     font-family: "RobotoMono", monospace;
-	background: #eee; 
-	border-radius: 3px; }
+	  border-radius: 3px; }
   article section.page p > code,
   article section.page li code,
   article section.page table code {

--- a/docs/themes/hugo-theme-docdock-master/static/theme-flex/style.css
+++ b/docs/themes/hugo-theme-docdock-master/static/theme-flex/style.css
@@ -366,7 +366,7 @@ article section.page {
       vertical-align: bottom; }
   article section.page code {
     font-family: "RobotoMono", monospace;
-	border-radius: 3px; }
+    border-radius: 3px; }
   article section.page p > code,
   article section.page li code,
   article section.page table code {


### PR DESCRIPTION
Before:
![2ZS~DS254OMG%2AY%E1R)QI](https://user-images.githubusercontent.com/42398278/202835104-9b4b00e3-fb44-448d-aedb-660694d687a7.png)

After:
![~6IT(}%ROU@_WM$ HSDA9G](https://user-images.githubusercontent.com/42398278/202835109-1cb2a4f9-8813-42c1-8543-685f67a0491b.png)
