### PR TITLE
Update helper module documentation according to community pain points

### DIFF
--- a/docs/content/english/Multiplayer/hosting_server.md
+++ b/docs/content/english/Multiplayer/hosting_server.md
@@ -8,6 +8,8 @@ weight = 5
 Enable Tools within your Steam Library. `Mount & Blade II: Dedicated Server` should appear on your list. Download and install it.
 
 ## Hosting
+By default, dedicated servers use UDP port 7210. You must have a visible (public) IP address on the internet as well as the aforementioned port being accessible.
+
 Anonymous hosting is not supported. You will have to create a server token by going in-game first.
 
 ### Generating a Token
@@ -108,14 +110,18 @@ If you do not want the web panel to be accessible from outside the local network
 ##### In-Game Map Downloads
 We also present a way to allow players to download your server’s map files through an in-game panel. As the server host, there are some conditions you must ensure to get this functioning:
 
-* The maps to be served must be located within the `DedicatedCustomServerHelper` module’s `SceneObj` directory, in the same way a typical module contains scenes. You can create the directory by hand if it is missing.
-* The maps to be served must be “registered” through either the *Map configuration* option or the `add_map_to_automated_battle_pool` command. In other words, only maps playable on the server are served.
+* The maps to be served must be located within **ONLY** the `DedicatedCustomServerHelper` module’s `SceneObj` directory, in the same way a typical module contains scenes. You can create the directory by hand if it is missing.
+* The maps to be served must be “registered” through either the `Map` configuration option or the `add_map_to_automated_battle_pool` command. In other words, only maps playable on the server are served.
+
+Note that having the scene loaded in multiple modules will cause issues such as the scene not being shown on the download panel.
 
 For the players to be able to open the download panel, they will need to launch the game with the `DedicatedCustomServerHelper` module loaded. Now, they can right click on a custom server list entry, which will open a context menu with the option to open the download panel for the server. Once a map is successfully downloaded, there is no need to restart the game, they should be able to join your server as is.
 
 <img src="/img/hosting_server/hosting_server_7.png" width="600px" />
 
 Note that this feature is intended to support simple use cases. This is not a module manager feature, and will not be able to support maps that require other assets (ModuleData, Prefabs, etc.) spread throughout a given module. Only the `SceneObj` directory contents are transferred between the server and the client.
+
+If the lack of prefab support is a concern, you may be able to make the scene usable through the helper module by breaking the prefabs. Open the scene in the editor, select all entity objects, right click and select *Break Prefab*.
 
 ## FAQ
 ##### Does Steam need to stay open for hosting?
@@ -135,9 +141,6 @@ Yes, your server will be accessible by everyone unless you make it password prot
 
 ##### How many servers can I host?
 There is a limit to the number of servers you can host simultaneously. Currently, you can host up to 5 servers.
-
-##### My server is available on the list but players can’t join it. What is wrong?
-By default, dedicated servers are using UDP port 7210. You must have a visible (public) IP address on the Internet as well as the aforementioned port being accessible.
 
 ##### What are the hardware requirements?
 It depends on the game mode and the player count. With the default configurations, we are hosting our games:

--- a/docs/content/russian/Multiplayer/hosting_server.md
+++ b/docs/content/russian/Multiplayer/hosting_server.md
@@ -11,6 +11,8 @@ Enable Tools within your Steam Library. `Mount & Blade II: Dedicated Server` sho
 Anonymous hosting is not supported. You will have to create a server token by going in-game first.
 
 ### Generating a Token
+By default, dedicated servers use UDP port 7210. You must have a visible (public) IP address on the internet as well as the aforementioned port being accessible.
+
 Launch `Mount & Blade II: Bannerlord` multiplayer and log into the game lobby:
 
 <img src="/img/hosting_server/hosting_server_1.jpg" width="900px" />
@@ -108,14 +110,18 @@ If you do not want the web panel to be accessible from outside the local network
 ##### In-Game Map Downloads
 We also present a way to allow players to download your server’s map files through an in-game panel. As the server host, there are some conditions you must ensure to get this functioning:
 
-* The maps to be served must be located within the `DedicatedCustomServerHelper` module’s `SceneObj` directory, in the same way a typical module contains scenes. You can create the directory by hand if it is missing.
-* The maps to be served must be “registered” through either the *Map configuration* option or the `add_map_to_automated_battle_pool` command. In other words, only maps playable on the server are served.
+* The maps to be served must be located within **ONLY** the `DedicatedCustomServerHelper` module’s `SceneObj` directory, in the same way a typical module contains scenes. You can create the directory by hand if it is missing.
+* The maps to be served must be “registered” through either the `Map` configuration option or the `add_map_to_automated_battle_pool` command. In other words, only maps playable on the server are served.
+
+Note that having the scene loaded in multiple modules will cause issues such as the scene not being shown on the download panel.
 
 For the players to be able to open the download panel, they will need to launch the game with the `DedicatedCustomServerHelper` module loaded. Now, they can right click on a custom server list entry, which will open a context menu with the option to open the download panel for the server. Once a map is successfully downloaded, there is no need to restart the game, they should be able to join your server as is.
 
 <img src="/img/hosting_server/hosting_server_7.png" width="600px" />
 
 Note that this feature is intended to support simple use cases. This is not a module manager feature, and will not be able to support maps that require other assets (ModuleData, Prefabs, etc.) spread throughout a given module. Only the `SceneObj` directory contents are transferred between the server and the client.
+
+If the lack of prefab support is a concern, you may be able to make the scene usable through the helper module by breaking the prefabs. Open the scene in the editor, select all entity objects, right click and select *Break Prefab*.
 
 ## FAQ
 ##### Does Steam need to stay open for hosting?
@@ -135,9 +141,6 @@ Yes, your server will be accessible by everyone unless you make it password prot
 
 ##### How many servers can I host?
 There is a limit to the number of servers you can host simultaneously. Currently, you can host up to 5 servers.
-
-##### My server is available on the list but players can’t join it. What is wrong?
-By default, dedicated servers are using UDP port 7210. You must have a visible (public) IP address on the Internet as well as the aforementioned port being accessible.
 
 ##### What are the hardware requirements?
 It depends on the game mode and the player count. With the default configurations, we are hosting our games:

--- a/docs/content/schinese/Multiplayer/hosting_server.md
+++ b/docs/content/schinese/Multiplayer/hosting_server.md
@@ -9,6 +9,8 @@ weight = 5
 在你的 Steam 库中选到“工具”，你会在列表里看到 `Mount & Blade II: Dedicated Server`。下载并安装它。
 
 ## 搭建
+By default, dedicated servers use UDP port 7210. You must have a visible (public) IP address on the internet as well as the aforementioned port being accessible.
+
 服务器不支持匿名搭建，你需要先进入游戏生成一个令牌（Token）。
 
 ### 生成一个令牌（Token）
@@ -105,14 +107,18 @@ weight = 5
 ##### 游戏内地图下载
 我们还提供了一种允许玩家通过游戏内面板下载服务器的地图文件的方式。作为服务器主机，你必须要满足一些条件才能让这个功能发挥作用：
 
-* 地图文件必须置于 `DedicatedCustomServerHelper` 模组的 `SceneObj` 目录下，就像一个典型的包含场景的模组一样。如果没有该目录，你可以手动新建一个。
+* 地图文件必须置于 **ONLY** `DedicatedCustomServerHelper` 模组的 `SceneObj` 目录下，就像一个典型的包含场景的模组一样。如果没有该目录，你可以手动新建一个。
 * 要把这个地图提供给玩家，必须通过 `Map` 选项或  `add_map_to_automated_battle_pool` 命令“注册”到服务器。
+
+Note that having the scene loaded in multiple modules will cause issues such as the scene not being shown on the download panel.
 
 为了让玩家能够打开下载面板，他们需要在加载了 `DedicatedCustomServerHelper` 模组后启动游戏。现在，他们可以鼠标右击自定义服务器列表项，然后会打开一个上下文菜单，其中会有打开该服务器下载面板的选项。地图下载成功后，无需重新启动游戏，他们应该就能直接加入你的服务器。
 
 <img src="/img/hosting_server/hosting_server_7.png" width="600px" />
 
 请注意，这个功能是用于支持这一简单的使用场景。这不是一个模组管理器功能，也无法支持获取给定的模组分布在其他资产（如 ModuleData、Prefabs 等）中的地图。只有 `SceneObj` 目录下的内容会在服务端和客户端之间传输。
+
+If the lack of prefab support is a concern, you may be able to make the scene usable through the helper module by breaking the prefabs. Open the scene in the editor, select all entity objects, right click and select *Break Prefab*.
 
 ## 常见问题
 ##### 在服务器搭建时需要 Steam 保持运行吗？
@@ -132,9 +138,6 @@ weight = 5
 
 ##### 我可以搭建多少服务器？
 你可以同时运行的服务器数量是有限的。目前，你最多可以同时运行 5 个服务器。
-
-##### 我的服务器在列表里显示了，但玩家无法加入。什么问题？
-默认情况下，独立服务器使用 UDP 端口 7210。你必须在互联网上有一个大家可以访问的（公共）IP 地址，以及上述端口也必须可以访问到。
 
 ##### 硬件要求是什么？
 这需要看是何种游戏模式以及玩家数量。这是我们搭建游戏服务器时，默认的配置：


### PR DESCRIPTION
This is long overdue, but here are changes to alleviate some of the hurdles the community (Modding Discord) have faced.

- UDP port 7210 was being mentioned way too late into the page
- Helper module requires that a scene be loaded in only one module, itself, to work properly
- Prefab support may be lacking, but breaking prefabs through the editor is an option worth consideration