### PR TITLE
Fixed: Typo in `overriding_assets.md`

### DIFF
--- a/docs/content/english/Asset Management/Asset Types/overriding_assets.md
+++ b/docs/content/english/Asset Management/Asset Types/overriding_assets.md
@@ -36,7 +36,7 @@ Currently moddable asset types are:
 
 ### Folder Hierarchy
 
-Asset system treats some folders in module directory specially according to their names. Here is the list of these folders and their uesages : 
+Asset system treats some folders in module directory specially according to their names. Here is the list of these folders and their usages : 
 
 - **Assets** : Includes editable *.tpac files which stores meta data of each asset.
 - **AssetSources** : Includes source files of imported assets(.psd, .fbx).


### PR DESCRIPTION
Fixed typo on line 39 and standardized newline at end of file.